### PR TITLE
Reduce noisyness of logs: Only log when meaningfull changes happen to…

### DIFF
--- a/common/annotate.go
+++ b/common/annotate.go
@@ -56,17 +56,18 @@ func NewAnnotator(ScannerVersion string, HubServer string) *Annotator {
 
 func mapMerge(base map[string]string, new map[string]string) map[string]string {
 	newMap := make(map[string]string)
-
 	if base != nil {
 		for k, v := range base {
 			newMap[k] = v
 		}
 	}
 	for k,v := range new {
-		if newMap[k] != "" {
-			log.Printf("Warning! Overwriting %d with value %d->%d",k, v, v)
+		// if we're overwriting w/ a new value, log.  Don't overlog b/c we expect the arbiter
+		// to overwrite quite often (every 30 minutes checks in with KB).
+		if newMap[k] != "" && v != newMap[k] {
+			log.Printf("Image annotation update: [ %s ] FROM %s TO %s", k, newMap[k], v)
+			newMap[k] = v
 		}
-		newMap[k]=v
 	}
 	return newMap
 }

--- a/common/annotate_test.go
+++ b/common/annotate_test.go
@@ -27,6 +27,17 @@ func TestMapMerge(t *testing.T) {
 	if len(c) != 4{
 		t.Fail()
 	}
+
+	// make sure mutations work right, run w/ -v to make sure logging is working right.
+	a = map[string]string{"a":"b", "c":"d"}
+	b = map[string]string{"a":"b","c":"e"}
+	c = mapMerge(a,b)
+	if len(c) != 2{
+		t.Fail()
+	}
+	if c["c"] != "e" {
+		t.Fail()
+	}
 }
 
 func TestOpenshiftAnnotations(t *testing.T) {


### PR DESCRIPTION
… annotations, not for chron scans from KB