### PR TITLE
Make fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,20 @@
 BDS_VER ?= 3.6.2
 BUILD_NUMBER_FILE=build.txt
 
-all: clean build tar-install release-docker
+all: build tar-install release-docker
 
-tar-build: clean build tar-install
+tar-build: build tar-install
 
 clean: 
-	rm -Rf ./output/$(BDS_VER); mkdir ./output; mkdir ./output/$(BDS_VER);
+	rm -Rf ./output/$(BDS_VER) buildtime.txt
+	cd ./scanner; make clean
+	cd ./controller; make clean
+	cd ./arbiter; make clean
 
 build:
+	mkdir -p ./output/$(BDS_VER)
 	$(eval OS_BUILD_NUMBER=$(shell cat $(BUILD_NUMBER_FILE)))
+	date +"%m-%d-%y" > buildtime.txt
 
 	cd ./scanner; make BDS_SCANNER=$(BDS_VER) OCP_BUILD_NUMBER=$(OS_BUILD_NUMBER)
 	cd ./controller; make BDS_SCANNER=$(BDS_VER) OCP_BUILD_NUMBER=$(OS_BUILD_NUMBER)

--- a/arbiter/Makefile
+++ b/arbiter/Makefile
@@ -4,11 +4,8 @@ BUILD_TIME := $(shell cat ../buildtime.txt)
 LAST_COMMIT := $(shell git rev-parse HEAD)
 
 all:
-	#clean up from the past
-	rm -Rf ./output \
-	mkdir output
-	#Assumes build on Cent/RHEL7.x
-	\cp /etc/ssl/certs/ca-bundle.crt ca-certificates.crt
+	mkdir -p output
+	docker run centos cat /etc/ssl/certs/ca-bundle.crt > ca-certificates.crt
 	\cp ../LICENSE ./
 	
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags "-X main.bds_version=$(BDS_SCANNER) -X main.build_num=$(OCP_BUILD_NUMBER)" -o ./output/ose_arbiter ./cmd/arbiter
@@ -17,7 +14,7 @@ all:
 	docker save hub_ose_arbiter:$(BDS_SCANNER) > ./output/hub_ose_arbiter.tar
 
 travis:
-	mkdir output
+	mkdir -p output
 	# Travis isn't executing tests at this point
 	#cp /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt ca-certificates.crt
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags "-X main.bds_version=$(BDS_SCANNER) -X main.build_num=$(OCP_BUILD_NUMBER)" -o ./output/ose_arbiter ./cmd/arbiter
@@ -26,4 +23,5 @@ vet:
 	go fmt ${PKG_LIST}
 	go vet ${PKG_LIST}
 
-
+clean:
+	rm -Rf ./output ca-certificates.crt

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -4,12 +4,9 @@ BUILD_TIME := $(shell cat ../buildtime.txt)
 LAST_COMMIT := $(shell git rev-parse HEAD)
 
 all:
-	#clean up from the past
-	rm -Rf ./output \
-	mkdir output
+	mkdir -p output
 
-	#Assumes build on Cent/RHEL7.x
-	\cp /etc/ssl/certs/ca-bundle.crt ca-certificates.crt
+	docker run centos cat /etc/ssl/certs/ca-bundle.crt > ca-certificates.crt
 	\cp ../LICENSE ./
 
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags "-X main.bds_version=$(BDS_SCANNER) -X main.build_num=$(OCP_BUILD_NUMBER)" -o ./output/controller ./cmd/controller
@@ -22,5 +19,8 @@ vet:
 	go vet ${PKG_LIST}
 
 travis:
-	mkdir output
+	mkdir -p output
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags "-X main.bds_version=$(BDS_SCANNER) -X main.build_num=$(OCP_BUILD_NUMBER)" -o ./output/controller ./cmd/controller
+
+clean:
+	rm -Rf ./output ca-certificates.crt

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -3,16 +3,12 @@ BUILD_TIME := $(shell cat ../buildtime.txt)
 LAST_COMMIT := $(shell git rev-parse HEAD)
 
 all:
-	#clean up from the past
-	rm -Rf ./output \
-	mkdir output
-
-	rm -Rf ./build \
-	mkdir build
+	mkdir -p output build
 
 	GOOS=linux GOARCH=amd64 go build -o ./output/ose_scanner .
 
 	rm -Rf ./hub_scanner/scan.cli
+	curl -u "reader":"EGGlaptop4EGG_&" https://test-repo.blackducksoftware.com/artifactory/bds-hub-nightly/com/blackducksoftware/hub/scan.cli/${BDS_VER}/scan.cli-${BDS_VER}-zip.zip > ./hub_scanner/scan.cli-${BDS_VER}.zip
 	unzip ./hub_scanner/scan.cli-$(BDS_SCANNER).zip -d ./hub_scanner/scan.cli
 	if [ -d ./hub_scanner/scan.cli/scan.cli-$(BDS_SCANNER)-zip ]; then \cp -a ./hub_scanner/scan.cli/scan.cli-$(BDS_SCANNER)-zip/. ./hub_scanner/scan.cli/scan.cli-$(BDS_SCANNER); fi;
 	\cp ../LICENSE ./
@@ -23,5 +19,8 @@ all:
 	rm -Rf ./hub_scanner/scan.cli
 
 travis:
-	mkdir output
+	mkdir -p output
 	GOOS=linux GOARCH=amd64 go build -o ./output/ose_scanner .
+
+clean:
+	rm -Rf ./output ./build


### PR DESCRIPTION
Fixes for Makefiles:
- Separate out the build and clean tasks
- External dependencies are handled in the build process