### PR TITLE
first unit test

### DIFF
--- a/arbiter/pkg/arbiter/controllerinterface_test.go
+++ b/arbiter/pkg/arbiter/controllerinterface_test.go
@@ -1,0 +1,20 @@
+package arbiter
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestScanAbortLogic(t *testing.T) {
+	statusCode, logMessage, _, _, err := scanAbortLogic("abc", "123", make(map[string]*controllerDaemon), make(map[string]*assignImage), 0)
+	if statusCode != http.StatusNotFound {
+		t.Error("wrong status code, expected StatusNotFound")
+	}
+	expectedMessage := "Unknown controller [abc] claimed abort for image: 123\n"
+	if logMessage != expectedMessage {
+		t.Error("wrong log message, got", logMessage, "instead of", expectedMessage)
+	}
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}


### PR DESCRIPTION
First unit test -- this does two things:

 - splits `scanAbort` into testable logic and the code that works with all the dependencies
 - adds a unit test verifying the behavior of `scanAbortLogic` in the case that no controller daemon can be found